### PR TITLE
Remove emoji from notification markdown section

### DIFF
--- a/.github/workflows/pull-request-opened-notify-slack.yml
+++ b/.github/workflows/pull-request-opened-notify-slack.yml
@@ -38,8 +38,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*${{ github.event.pull_request.user.login }}* made the following changes: <${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}> :eyes:",
-                    "emoji": true
+                    "text": "*${{ github.event.pull_request.user.login }}* made the following changes: <${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}> :eyes:"
                   }
                 }
               ]


### PR DESCRIPTION
This field is only needed with 'plain_text' sections. 'markdwn' sections always have emoji and adding the 'emoji' field causes a validation error.